### PR TITLE
Add header template

### DIFF
--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -39,6 +39,7 @@
     <Setter Property="Padding" Value="0" />
     <Setter Property="SystemDecorations"
             Value="Full"/>
+    <Setter Property="TitleTemplate" Value="{StaticResource ManagedWindowHeaderTemplate}"/>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate>
@@ -52,88 +53,7 @@
                   Background="{TemplateBinding Background}">
 
               <!--Title Bar-->
-              <Grid Name="PART_TitleBar"
-                    ColumnDefinitions="Auto * Auto"
-                    Background="{DynamicResource ManagedWindow_TitleBarBackgroundBrush}">
-                <Grid.Styles>
-                  <Style Selector="Button">
-                    <Setter Property="Background" Value="Transparent"/>
-                  </Style>
-                </Grid.Styles>
-
-                <!-- Icon -->
-                <ContentPresenter Grid.Column="0"
-                                  VerticalAlignment="Center"
-                                  HorizontalAlignment="Center"
-                                  Content="{TemplateBinding Icon}" />
-                <!-- Title -->
-                <TextBlock Name="PART_Title"
-                           Grid.Column="1"
-                           Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
-                           VerticalAlignment="Center"
-                           FontFamily="{TemplateBinding FontFamily}"
-                           FontSize="{TemplateBinding FontSize}"
-                           FontWeight="{TemplateBinding FontWeight}"
-                           FontStyle="{TemplateBinding FontStyle}"
-                           Text="{TemplateBinding Title}"/>
-
-                <!-- System Decorations (aka buttons)-->
-                <StackPanel Grid.Column="2"
-                            Orientation="Horizontal"
-                            VerticalAlignment="Center"
-                            HorizontalAlignment="Right">
-                  <StackPanel.Spacing>
-                    <console:OnPlatformExtension x:TypeArguments="x:Double" Default="8" Console="-1" />
-                  </StackPanel.Spacing>
-                  <Button Name="PART_MinimizeButton"
-                          IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗕">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeMinimize"
-                                            Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                            Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
-                  <Button Name="PART_MaximizeButton"
-                          IsVisible="False"
-                          IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-
-                    <console:OnPlatform Console="🗖">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeMaximize"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
-                  <Button Name="PART_RestoreButton"
-                          IsVisible="False"
-                          IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗗">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeRestore"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
-                  <Button Name="PART_CloseButton"
-                          IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗙">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeClose"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
-                </StackPanel>
-              </Grid>
+                <ContentControl Name="PART_TitleBar" Template="{TemplateBinding TitleTemplate}" />
 
               <!-- window content-->
               <ContentPresenter Grid.Row="1"

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -53,7 +53,9 @@
                   Background="{TemplateBinding Background}">
 
               <!--Title Bar-->
-                <ContentControl Name="PART_TitleBar" Template="{TemplateBinding TitleTemplate}" />
+                <ContentControl Name="PART_TitleBar"
+                                DataContext="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                ContentTemplate="{TemplateBinding TitleTemplate}" />
 
               <!-- window content-->
               <ContentPresenter Grid.Row="1"

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -118,8 +118,8 @@ public class ManagedWindow : OverlayPopupHost
     /// <summary>
     /// Defines the <see cref="TitleTemplate"/> property.
     /// </summary>
-    public static readonly StyledProperty<IControlTemplate?> TitleTemplateProperty =
-        AvaloniaProperty.Register<ManagedWindow, IControlTemplate?>(nameof(TitleTemplate));
+    public static readonly StyledProperty<IDataTemplate?> TitleTemplateProperty =
+        AvaloniaProperty.Register<ManagedWindow, IDataTemplate?>(nameof(TitleTemplate));
 
     /// <summary>
     /// Defines the <see cref="WindowStartupLocation"/> property.
@@ -303,7 +303,7 @@ public class ManagedWindow : OverlayPopupHost
     /// <summary>
     /// Gets or sets the template for the window header.
     /// </summary>
-    public IControlTemplate? TitleTemplate
+    public IDataTemplate? TitleTemplate
     {
         get => GetValue(TitleTemplateProperty);
         set => SetValue(TitleTemplateProperty, value);

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
@@ -113,6 +114,12 @@ public class ManagedWindow : OverlayPopupHost
     /// </summary>
     public static readonly StyledProperty<object?> IconProperty =
         AvaloniaProperty.Register<ManagedWindow, object?>(nameof(Icon));
+
+    /// <summary>
+    /// Defines the <see cref="TitleTemplate"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IControlTemplate?> TitleTemplateProperty =
+        AvaloniaProperty.Register<ManagedWindow, IControlTemplate?>(nameof(TitleTemplate));
 
     /// <summary>
     /// Defines the <see cref="WindowStartupLocation"/> property.
@@ -291,6 +298,15 @@ public class ManagedWindow : OverlayPopupHost
     {
         get => GetValue(IconProperty);
         set => SetValue(IconProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the template for the window header.
+    /// </summary>
+    public IControlTemplate? TitleTemplate
+    {
+        get => GetValue(TitleTemplateProperty);
+        set => SetValue(TitleTemplateProperty, value);
     }
 
     /// <summary>
@@ -1009,32 +1025,34 @@ public class ManagedWindow : OverlayPopupHost
 
         //if (this.Theme == null)
         //    this.Theme = (ControlTheme)this.FindResource("ManagedWindow");
-        _title = e.NameScope.Find<TextBlock>(PART_Title);
-
         _titleBar = e.NameScope.Find<Control>(PART_TitleBar);
+        var titleScope = _titleBar != null ? NameScope.GetNameScope(_titleBar) : null;
+
+        _title = e.NameScope.Find<TextBlock>(PART_Title) ?? titleScope?.Find<TextBlock>(PART_Title);
+
         if (_titleBar != null)
         {
             SetupDragging(_titleBar);
         }
 
-        var partMinimizeButton = e.NameScope.Find<Button>(PART_MinimizeButton);
+        var partMinimizeButton = e.NameScope.Find<Button>(PART_MinimizeButton) ?? titleScope?.Find<Button>(PART_MinimizeButton);
         if (partMinimizeButton != null)
         {
             partMinimizeButton.Click += OnMinimizeClick;
         }
 
-        var partMaximizeButton = e.NameScope.Find<Button>(PART_MaximizeButton);
+        var partMaximizeButton = e.NameScope.Find<Button>(PART_MaximizeButton) ?? titleScope?.Find<Button>(PART_MaximizeButton);
         if (partMaximizeButton != null)
         {
             partMaximizeButton.Click += OnMaximizeClick;
         }
-        var partRestoreButton = e.NameScope.Find<Button>(PART_RestoreButton);
+        var partRestoreButton = e.NameScope.Find<Button>(PART_RestoreButton) ?? titleScope?.Find<Button>(PART_RestoreButton);
         if (partRestoreButton != null)
         {
             partRestoreButton.Click += OnRestoreClick;
         }
 
-        var partCloseButton = e.NameScope.Find<Button>(PART_CloseButton);
+        var partCloseButton = e.NameScope.Find<Button>(PART_CloseButton) ?? titleScope?.Find<Button>(PART_CloseButton);
         if (partCloseButton != null)
         {
             partCloseButton.Click += OnCloseClick;

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindowHeader.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindowHeader.axaml
@@ -1,0 +1,90 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+                    xmlns:console="https://github.com/jinek/consolonia"
+                    xmlns:wm="using:Iciclecreek.Avalonia.WindowManager">
+
+  <ControlTemplate x:Key="ManagedWindowHeaderTemplate">
+    <Grid ColumnDefinitions="Auto * Auto"
+          Background="{DynamicResource ManagedWindow_TitleBarBackgroundBrush}">
+      <Grid.Styles>
+        <Style Selector="Button">
+          <Setter Property="Background" Value="Transparent" />
+        </Style>
+      </Grid.Styles>
+
+      <!-- Icon -->
+      <ContentPresenter Grid.Column="0"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Content="{Binding Icon, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}" />
+      <!-- Title -->
+      <TextBlock Name="PART_Title"
+                 Grid.Column="1"
+                 Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
+                 VerticalAlignment="Center"
+                 FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}"
+                 FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}"
+                 FontWeight="{Binding FontWeight, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}"
+                 FontStyle="{Binding FontStyle, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}"
+                 Text="{Binding Title, RelativeSource={RelativeSource AncestorType=wm:ManagedWindow}}" />
+
+      <!-- System Decorations (aka buttons)-->
+      <StackPanel Grid.Column="2"
+                  Orientation="Horizontal"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Right">
+        <StackPanel.Spacing>
+          <console:OnPlatformExtension x:TypeArguments="x:Double" Default="8" Console="-1" />
+        </StackPanel.Spacing>
+        <Button Name="PART_MinimizeButton"
+                IsTabStop="True"
+                Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
+          <console:OnPlatform Console="🗕">
+            <console:OnPlatform.Default>
+              <iconPacks:Codicons Kind="ChromeMinimize"
+                                  Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                  Height="{StaticResource ManagedWindow_SystemIconSize}" />
+            </console:OnPlatform.Default>
+          </console:OnPlatform>
+        </Button>
+        <Button Name="PART_MaximizeButton"
+                IsVisible="False"
+                IsTabStop="True"
+                Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
+          <console:OnPlatform Console="🗖">
+            <console:OnPlatform.Default>
+              <iconPacks:Codicons Kind="ChromeMaximize"
+                                  Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                  Height="{StaticResource ManagedWindow_SystemIconSize}" />
+            </console:OnPlatform.Default>
+          </console:OnPlatform>
+        </Button>
+        <Button Name="PART_RestoreButton"
+                IsVisible="False"
+                IsTabStop="True"
+                Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
+          <console:OnPlatform Console="🗗">
+            <console:OnPlatform.Default>
+              <iconPacks:Codicons Kind="ChromeRestore"
+                                  Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                  Height="{StaticResource ManagedWindow_SystemIconSize}" />
+            </console:OnPlatform.Default>
+          </console:OnPlatform>
+        </Button>
+        <Button Name="PART_CloseButton"
+                IsTabStop="True"
+                Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
+          <console:OnPlatform Console="🗙">
+            <console:OnPlatform.Default>
+              <iconPacks:Codicons Kind="ChromeClose"
+                                  Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                  Height="{StaticResource ManagedWindow_SystemIconSize}" />
+            </console:OnPlatform.Default>
+          </console:OnPlatform>
+        </Button>
+      </StackPanel>
+    </Grid>
+  </ControlTemplate>
+
+</ResourceDictionary>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindowHeader.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindowHeader.axaml
@@ -4,7 +4,7 @@
                     xmlns:console="https://github.com/jinek/consolonia"
                     xmlns:wm="using:Iciclecreek.Avalonia.WindowManager">
 
-  <ControlTemplate x:Key="ManagedWindowHeaderTemplate">
+  <DataTemplate x:Key="ManagedWindowHeaderTemplate" DataType="wm:ManagedWindow">
     <Grid ColumnDefinitions="Auto * Auto"
           Background="{DynamicResource ManagedWindow_TitleBarBackgroundBrush}">
       <Grid.Styles>
@@ -85,6 +85,6 @@
         </Button>
       </StackPanel>
     </Grid>
-  </ControlTemplate>
+  </DataTemplate>
 
 </ResourceDictionary>

--- a/source/Iciclecreek.Avalonia.WindowManager/WindowManagerTheme.xaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/WindowManagerTheme.xaml
@@ -11,6 +11,7 @@
       <!-- control styles -->
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml" />
+        <ResourceInclude Source="avares://Iciclecreek.Avalonia.WindowManager/ManagedWindowHeader.axaml" />
       </ResourceDictionary.MergedDictionaries>
 
       <!-- themed resources -->


### PR DESCRIPTION
## Summary
- add new ManagedWindowHeader axaml template for title bar
- update theme includes
- reference new header template from ManagedWindow
- find named parts in header template
- add TitleTemplate styled property to allow template override

## Testing
- `dotnet build source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj -v:m`


------
https://chatgpt.com/codex/tasks/task_e_6873a1d14fec832299f1c9750343ffc3